### PR TITLE
Fix to issue #3: pitch-shifted playback

### DIFF
--- a/core/cmds/play.py
+++ b/core/cmds/play.py
@@ -52,7 +52,7 @@ async def stream_to(voice_client, url, ctx):
     converter = (
         ffmpeg
         .input(url, re=None)
-        .output("pipe:1", format="s16le")
+        .output("pipe:1", format="s16le", ar='48k')
         .run_async(pipe_stdout=True)
     )
     voice_client.play(discord.PCMAudio(converter.stdout))


### PR DESCRIPTION
Fix to issue #3. Discord requires audio streams to be [48khz 16-bit PCM](https://discordpy.readthedocs.io/en/latest/api.html#discord.AudioSource). The converter was outputting 44.1khz instead. Now the FFmpeg converter outputs 48khz audio instead.